### PR TITLE
Update the sym method

### DIFF
--- a/lib/jsobfu.rb
+++ b/lib/jsobfu.rb
@@ -88,7 +88,7 @@ class JSObfu
   # @param [String] sym the name of the variable or function 
   # @return [String] the obfuscated name
   def sym(sym)
-    raise RuntimeError, "Must obfuscate before calling #sym" if @renames.nil?
+    return sym.to_s if @renames.nil?
     @renames[sym.to_s]
   end
 


### PR DESCRIPTION
When obfuscate is called, it doesn't necessarily have to obfuscate. In that case, the sym method should just return the original sym name, and not raise an exception. If it throws an exception, some metasploit modules basically are forced to use the JsObfuscate option when it wants to use the sym method.
