### PR TITLE
Fix a bug in obfuscating unicode strings.

### DIFF
--- a/lib/jsobfu/utils.rb
+++ b/lib/jsobfu/utils.rb
@@ -357,7 +357,7 @@ module JSObfu::Utils
           str.slice!(0, $1.length)
         end
       else
-        char = str.slice!(0,1).unpack("C").first
+        char = str.slice!(0,1).unpack("U").first
       end
       encoded_bytes << rand_base(char) if char
     end

--- a/spec/integration/unicode_strings.js
+++ b/spec/integration/unicode_strings.js
@@ -1,0 +1,9 @@
+function unicodeString() {
+  return '你好';
+}
+
+this.test = function() {
+  var unicode = unicodeString();
+  if (unicode !== '你好') throw 'UNICODE CHARS DO NOT MATCH: '+unicode;
+  return 'unicode chars match'
+};

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -5,7 +5,12 @@ require 'execjs'
 unless ENV['INTEGRATION'] == 'false'
 
 describe 'Integrations' do
+  match = ENV['MATCH']
   Dir.glob(Pathname.new(__FILE__).dirname.join('integration/**.js').to_s).each do |path|
+    if match and !path.downcase.include?(match.downcase)
+      next
+    end
+
     js = File.read(path)
 
     if js =~ /\/\/@wip/

--- a/spec/jsobfu/utils_spec.rb
+++ b/spec/jsobfu/utils_spec.rb
@@ -21,7 +21,7 @@ describe JSObfu::Utils do
 
   describe '#rand_text_alpha' do
     let(:len) { 15 }
-    
+
     # generates a new random string on every call
     def output; JSObfu::Utils.rand_text_alpha(len); end
 
@@ -34,7 +34,7 @@ describe JSObfu::Utils do
     end
   end
 
-  describe '#rand_text' do    
+  describe '#rand_text' do
     let(:len) { 5 }
     let(:charset) { described_class::ALPHA_CHARSET }
 


### PR DESCRIPTION
This fixes issue #12. We were consuming chars from a Javascript string with unpack('C'), which fails for unicode characters. An integration test is added to ensure unicode chars come out the same way.