### PR TITLE
Fix #14, a bug where successive calls to obfuscate might fail

### DIFF
--- a/lib/jsobfu.rb
+++ b/lib/jsobfu.rb
@@ -96,6 +96,9 @@ class JSObfu
     # Enter all of the renames into current scope
     @scope.renames.merge!(@renames || {})
 
+    # Ensure the scope itself "remembers" the new names in case it is re-used
+    @scope.merge!(@renames.invert || {})
+
     self
   end
 

--- a/lib/jsobfu/scope.rb
+++ b/lib/jsobfu/scope.rb
@@ -24,7 +24,7 @@ class JSObfu::Scope < Hash
     parent opener event frameElement Error TypeError setTimeout setInterval
     top arguments Array Date
   )
-  
+
   # @return [JSObfu::Scope] parent that spawned this scope
   attr_accessor :parent
 


### PR DESCRIPTION
To trigger the bug in issue #14, we have to modify `random_var_name` a bit to make it generate the same value more than once. In `lib/jsobfu.rb`, replace `random_var_name` with this rigged stub:

```
  def random_var_name
    len = @min_len
    text = nil
    loop do
      text ||= 'a'
      unless has_key?(text) or
        RESERVED_KEYWORDS.include?(text) or
        BUILTIN_VARS.include?(text)

        self[text] = nil

        return text
      end
      text = random_string(len)
      len += 1
    end
  end
```

This will always attempt to assign 'a' as a new variable name before choosing a different random name. 

- [ ] Now run the failing spec, it should pass:

```
rspec ./spec/jsobfu_spec.rb:116
```

- [ ] Running the same spec with the same stub in `lib/jsobfu.rb` on master should fail.