### PR TITLE
Fix #14, a bug where successive calls to obfuscate might fail #15

### DIFF
--- a/lib/jsobfu/obfuscator.rb
+++ b/lib/jsobfu/obfuscator.rb
@@ -55,7 +55,8 @@ class JSObfu::Obfuscator < JSObfu::ECMANoWhitespaceVisitor
 
     ret = super
 
-    scope.pop!
+    # maintain a single top-level scope
+    scope.pop!(retain: scope.depth == 0)
 
     ret
   end


### PR DESCRIPTION
This is a neater fix for #14, that preserves used top-level var names across successive obfuscate calls.

To trigger the bug in issue #14, we have to modify `random_var_name` a bit to make it generate the same value more than once. In `lib/jsobfu/scope.rb`, replace `random_var_name` with this rigged stub:

```
  def random_var_name
    len = @min_len
    text = nil
    loop do
      text ||= 'a'
      unless has_key?(text) or
        RESERVED_KEYWORDS.include?(text) or
        BUILTIN_VARS.include?(text)

        self[text] = nil

        return text
      end
      text = random_string(len)
      len += 1
    end
  end
```

This will always attempt to assign 'a' as a new variable name before choosing a different random name. 
- [ ] Now run the failing spec, it should pass:

```
rspec ./spec/jsobfu_spec.rb:116
```
- [ ] Running the same spec with the same stub in `lib/jsobfu.rb` on master should fail.
