### PR TITLE
Add --preserved-identifiers and expose --global option to jsobfu CLI.

### DIFF
--- a/bin/jsobfu
+++ b/bin/jsobfu
@@ -1,8 +1,28 @@
 #!/usr/bin/env ruby
 require 'jsobfu'
+require 'optparse'
 
-iterations = (ARGV[0] || 1).to_i
+iterations = [(ARGV[0] || 1).to_i, 1].max
+
+preserved_identifiers = []
+global = 'window'
+
+opt_parser = OptionParser.new do |opts|
+  opts.banner = 'Usage: jsobfu [iterations] [options]'
+  opts.on('--preserved-identifiers id1,id2') do |ids|
+    preserved_identifiers += ids.split(',')
+  end
+  opts.on('--global window') do |global_opt|
+    global = global_opt
+  end
+end
+
+opt_parser.parse(ARGV)
 
 js = JSObfu.new(STDIN.read)
 
-puts js.obfuscate(iterations: iterations)
+puts js.obfuscate(
+  iterations: iterations,
+  preserved_identifiers: preserved_identifiers,
+  global: global
+)

--- a/jsobfu.gemspec
+++ b/jsobfu.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'jsobfu'
-  spec.version       = '0.3.0'
-  spec.date          = '2014-04-09'
+  spec.version       = '0.4.0'
   spec.summary       = "A Javascript code obfuscator"
   spec.authors       = ["James Lee", "Joe Vennix"]
   spec.email         = 'joev@metasploit.com'

--- a/lib/jsobfu.rb
+++ b/lib/jsobfu.rb
@@ -62,6 +62,7 @@ class JSObfu
   # @option opts [Boolean] :memory_sensitive the execution environment is sensitive
   #   to changes in memory usage (e.g. a heap spray). This disables string transformations
   #   and other "noisy" obfuscation tactics. (false)
+  # @option opts [Array<String>] :preserved_identifiers A list of identifiers to NOT obfuscate
   # @return [self]
   def obfuscate(opts={})
     return self if JSObfu.disabled?


### PR DESCRIPTION
Adds a top-level option `:preserved_identifiers` that allows passing a list of identifiers that will NOT be obfuscated. This can help when using jsobfu with various build tools (like the requirejs compiler, which needs to see the identifier "define" to continue parsing).

### Verification
- [x] Change `require 'jsobfu'` in the `/bin/jsobfu` file to `require './lib/jsobfu'`.
- [x] Run `jsobfu -h` to view options
- [x] Running `echo "alert(1)" | ./bin/jsobfu --preserved-identifiers=alert` still contains the string "alert"
- [x] Specs pass